### PR TITLE
Don't expose views when account handling is off

### DIFF
--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -90,20 +90,23 @@ class WikiURLPatterns(object):
         return urlpatterns
 
     def get_accounts_urls(self):
-        urlpatterns = [
-            url('^_accounts/sign-up/$',
-                self.signup_view_class.as_view(),
-                name='signup'),
-            url('^_accounts/logout/$',
-                self.logout_view_class.as_view(),
-                name='logout'),
-            url('^_accounts/login/$',
-                self.login_view_class.as_view(),
-                name='login'),
-            url('^_accounts/settings/$',
-                self.settings_view_class.as_view(),
-                name='update'),
-        ]
+        if settings.ACCOUNT_HANDLING:
+            urlpatterns = [
+                url('^_accounts/sign-up/$',
+                    self.signup_view_class.as_view(),
+                    name='signup'),
+                url('^_accounts/logout/$',
+                    self.logout_view_class.as_view(),
+                    name='logout'),
+                url('^_accounts/login/$',
+                    self.login_view_class.as_view(),
+                    name='login'),
+                url('^_accounts/settings/$',
+                    self.settings_view_class.as_view(),
+                    name='update'),
+            ]
+        else:
+            urlpatterns = []
         return urlpatterns
 
     def get_revision_urls(self):


### PR DESCRIPTION
Since the PR adds yet another possible way of unintended entry when account handling is OFF, let's ensure that it truly is OFF.
